### PR TITLE
feat(scripts): download all air pods images for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+_testImages/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "collect-images": "deno run --allow-read --allow-write --allow-net ./scripts/imageCollector.ts"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/scripts/imageCollector.ts
+++ b/scripts/imageCollector.ts
@@ -1,0 +1,48 @@
+import { resolve, join } from 'https://deno.land/std/path/mod.ts'
+import { red, green } from 'https://deno.land/std/fmt/colors.ts'
+import { range } from 'https://deno.land/x/fae/mod.ts'
+
+const imageRootPath =
+  'https://www.apple.com/105/media/us/airpods-pro/2019/1299e2f5_9206_4470_b28e_08307a42f19b/anim/sequence/large/04-explode-tips'
+const distDir = resolve(Deno.cwd(), '_testImages')
+const imgSuffix = '.jpg'
+const limit = 300
+
+const downloadImage = async (image: string, distPath: string) => {
+  const res = await fetch(image)
+  const body = new Uint8Array(await res.arrayBuffer())
+  await Deno.writeFile(distPath, body)
+  console.log(green('[success]'), distPath)
+}
+
+const collectImages = async (
+  imageRootPath: string,
+  distDir: string,
+  imgSuffix: string,
+  limit: number
+) => {
+  await Deno.mkdir(distDir, { recursive: true })
+  return Promise.all(
+    range(0, limit).map((index) => {
+      try {
+        const filename = ('' + index).padStart(4, '0') + imgSuffix
+        const image = join(imageRootPath, filename)
+        const distPath = resolve(distDir, filename)
+        return downloadImage(image, distPath)
+      } catch (err) {
+        console.log(red('[error]'), err)
+        throw err
+      }
+    })
+  )
+}
+
+const successMessage = green('\nDownload Complete.')
+const errorMessage = red('\nDownload Failed.')
+
+try {
+  await collectImages(imageRootPath, distDir, imgSuffix, limit)
+  console.log(successMessage)
+} catch {
+  console.log(errorMessage)
+}


### PR DESCRIPTION
# Change

1. feat(scripts): download all air pods images for testing

## Description

### 參數設定

- `imageRootPath`: apple 官網的圖片根路徑
- `distDir`: 下載的圖片輸出至此資料夾
- `imgSuffix`: 圖片副檔名
- `limit`: 最大圖片下載數量

### 使用方法

`npm run collect-images`

此工具利用 Deno，所以必須先安裝 [Deno](https://deno.land/)
